### PR TITLE
Applying: Background size adjustment for home section

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -116,6 +116,7 @@ html {
 .home {
   display: flex;
   background: url("/src/img/banner-bg.png") top no-repeat;
+  background-size: cover;
   color: var(--color-white);
   height: 100vh;
   min-height: 500px;


### PR DESCRIPTION
Ao abrir o site em monitores com proporção ultrawide, o background "banner-bg.png" não estava se ajustando ao tamanho total da tela. Como resolução foi aplicado a propriedade background-size: cover;